### PR TITLE
Fix serial context

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,8 +177,10 @@ pub fn run_node_parallel<'a>(
         let values = run_threads_with_context(nodes, &gc_opt);
 
         let (success, diff_vec) = values;
-        for diff in diff_vec.unwrap() {
-            mgc.take_diff(diff);
+        if let Some(diff_vec) = diff_vec {
+            for diff in diff_vec {
+                mgc.take_diff(diff);
+            }
         }
         (success, None)
     } else {


### PR DESCRIPTION
fixes issue where a serial node nested inside a parallel node cannot let its nodes (that are in series) see each other's context because since the serial node is a child of a parallel node then it does not have a mutable context.

This fixes that issue by detecting that case and creating a clone of the immutable context to be mutable temporarily to allow the serial nodes visibility of whats going on.

